### PR TITLE
Added support for SPI MCP41HV51

### DIFF
--- a/src/PulseWelder/src/PulseWelder.cpp
+++ b/src/PulseWelder/src/PulseWelder.cpp
@@ -159,7 +159,7 @@ void setup()
   }
 
   // Setup Digital Pot. Must setup INA219 before the Digital Pot due to the shared i2c.
-  if (initDigitalPot(POT_I2C_ADDR) == false) {
+  if (initDigitalPot(POT_I2C_ADDR, POT_CS) == false) {
     systemError |= ERROR_DIGPOT;
   }
 
@@ -169,10 +169,10 @@ void setup()
 
   // Set Welding Current (Digital Pot).
   if (arcSwitch == ARC_ON) {
-    setPotAmps(setAmps, POT_I2C_ADDR, true);
+    setPotAmps(setAmps, true);
   }
   else {
-    setPotAmps(SET_AMPS_DISABLE, POT_I2C_ADDR, true);
+    setPotAmps(SET_AMPS_DISABLE, true);
   }
 
   // Init SPIFFS (SPIFFS is not used in this project).

--- a/src/PulseWelder/src/PulseWelder.h
+++ b/src/PulseWelder/src/PulseWelder.h
@@ -25,6 +25,7 @@
 #define OC_PIN 34
 #define VP_PIN 36
 #define VN_PIN 39
+#define POT_CS 26 // if using SPI POT MCP41HV51, not I2C MCP45HV51
 // #define DEBUG_PIN 2
 
 // TFT Pin Definitions (Using LoLin D32 Pro defaults)
@@ -145,13 +146,10 @@ void stopBle(void);
 
 // Digital Pot Protoypes
 bool digitalPotWrite(byte dataValue,
-                     byte memAddr,
-                     byte chipAddr);
-byte digitalPotRead(byte memAddr,
-                    byte chipAddr);
-bool initDigitalPot(byte chipAddr);
+                     byte memAddr);
+byte digitalPotRead(byte memAddr);
+bool initDigitalPot(byte chipAddr, int spi_cs);
 void setPotAmps(byte ampVal,
-                byte chipAddr,
                 bool verbose);
 
 // Display Prototypes

--- a/src/PulseWelder/src/digPot.cpp
+++ b/src/PulseWelder/src/digPot.cpp
@@ -1,7 +1,7 @@
 /*
    File: digPot.cpp
    Project: ZX7-200 MMA Stick Welder Controller with Pulse Mode.
-   Target Chip: Microchip MCP41HV51 Digital Pot IC. 5K ohms, 8-Bit.
+   Target Chip: Microchip MCP4xHV51 Digital Pot IC. 5K ohms, 8-Bit. MCP41 = SPI, MCP45 = I2C
    Version: 1.0
    Creation: Sep-11-2019
    Revised: Oct-24-2019
@@ -13,15 +13,72 @@
 
 #include <Arduino.h>
 #include <Wire.h>
+#include <SPI.h>
+
 #include "PulseWelder.h"
 #include "digPot.h"
 
 extern bool i2cInitComplete; // I2C Port Initialization is Complete flag.
+bool spiInitComplete; // SPI Port Initialization is Complete flag.
+
+static uint8_t csPin = 0;
+static uint8_t chipAddr; 
+
+static bool initDigitalPotShared()
+{
+  bool success = true;
+
+  const char* msg = "Initialized Digital POT Ohms. Set Minimum Welding Current.";
+  digitalPotWrite(POT_TCON_DEF, POT_TCON_ADDR); // Set Pot TCON register.
+
+    if (digitalPotRead(POT_TCON_ADDR) == POT_TCON_DEF) {
+      digitalPotWrite(POT_MIN, POT_WIPER_ADDR);   // Set Pot Wiper
+
+      if (digitalPotRead(POT_WIPER_ADDR) != POT_MIN) {
+        success = false;
+        msg = "Ohms Initialization Failed";
+      }
+    }
+    else {
+      success = false;
+      msg = "TCON Initialization Failed";
+    }
+
+    if (chipAddr != 0) { 
+      Serial.println("Digital POT at I2C Address 0x" + String(chipAddr, HEX) + ": " + msg);
+    }
+    if (csPin != 0) { 
+      Serial.println("Digital POT at SPI csPin " + String(csPin, DEC) + ": " + msg);
+    }
+    return success;
+}
 
 // *********************************************************************************************
 // Initialize the MCP41HV51 Digital Pot.
-bool initDigitalPot(byte chipAddr)
+bool initDigitalPotSPI(uint8_t csPinPot)
 {
+  csPin = csPinPot;
+  chipAddr = 0;
+
+  pinMode(csPin,OUTPUT);
+  digitalWrite(csPin, HIGH);
+  
+  if (spiInitComplete == false) // Check to see if other functions has already configured I2C port.
+  {
+    spiInitComplete = true;
+    SPI.begin();
+  }
+
+  return initDigitalPotShared();
+}
+
+// *********************************************************************************************
+// Initialize the MCP45HV51 Digital Pot.
+bool initDigitalPotI2C(byte chipAddrPot)
+{
+  chipAddr = chipAddrPot;
+  csPin = 0;
+
   bool success = false;
 
   if (i2cInitComplete == false) // Check to see if INA219 has already configured I2C port.
@@ -37,34 +94,26 @@ bool initDigitalPot(byte chipAddr)
     Serial.println("Digital POT Failure, Missing at Address 0x" + String(chipAddr, HEX) + ".");
   }
   else {
-    success = true;
-
-    digitalPotWrite(POT_TCON_DEF, POT_TCON_ADDR, chipAddr); // Set Pot TCON register.
-
-    if (digitalPotRead(POT_TCON_ADDR, chipAddr) == POT_TCON_DEF) {
-      digitalPotWrite(POT_MIN, POT_WIPER_ADDR, chipAddr);   // Set Pot Wiper
-
-      if (digitalPotRead(POT_WIPER_ADDR, chipAddr) == POT_MIN) {
-        Serial.println("Initialized Digital POT Ohms at Address 0x" + String(chipAddr, HEX) + ". Set Minimum Welding Current.");
-      }
-      else {
-        success = false;
-        Serial.println("Digital POT Ohms Initialization Failed at Address 0x" + String(chipAddr, HEX) + ".");
-      }
-    }
-    else {
-      success = false;
-      Serial.println("Digital POT TCON Initialization Failed at Address 0x" + String(chipAddr, HEX) + ".");
-    }
+    success = initDigitalPotShared();
   }
 
   return success;
 }
 
+bool initDigitalPot(byte chipAddrPot, int spi_cs)
+{
+  bool retval = initDigitalPotI2C(chipAddrPot);
+  if (retval == false && spi_cs != -1)
+  {
+    retval = initDigitalPotSPI(spi_cs);
+  }
+
+  return retval;
+}
 // *********************************************************************************************
 // Set the Pot wiper ohms for requested Welding Amps.
 // verbose = true for serial log status message.
-void setPotAmps(byte ampVal, byte chipAddr, bool verbose)
+void setPotAmps(byte ampVal, bool verbose)
 {
   byte potVal;
   uint16_t ohms;
@@ -72,7 +121,7 @@ void setPotAmps(byte ampVal, byte chipAddr, bool verbose)
   ampVal = constrain(ampVal, MIN_SET_AMPS, MAX_SET_AMPS);
   ohms   = map(ampVal, MIN_AMPS, MAX_AMPS, POT_MIN_OHMS, POT_MAX_OHMS); // Calculate Ohms.
   potVal = map(ampVal, MIN_AMPS, MAX_AMPS, 0x00, 0xff);                 // Calculate Dig Pot Wiper Value.
-  digitalPotWrite(potVal, POT_WIPER_ADDR, chipAddr);
+  digitalPotWrite(potVal, POT_WIPER_ADDR);
 
   if (verbose) {
     Serial.println("Set Welding Current to " + String(ampVal) + " Amps. Digital Pot is now " + String(ohms) + " Ohms, Data: 0x" +
@@ -81,29 +130,68 @@ void setPotAmps(byte ampVal, byte chipAddr, bool verbose)
 }
 
 // *********************************************************************************************
-// Primitive Write value for the MCP45HV51 digital Pot.
-bool digitalPotWrite(byte dataValue, byte memAddr, byte chipAddr)
+// Primitive Write value for the MCP4xHV51 digital Pot.
+bool digitalPotWrite(byte dataValue, byte memAddr)
 {
-  Wire.beginTransmission(chipAddr); // I2C Addr
-  Wire.write(memAddr | POT_WR_CMD); // Write Command
-  Wire.write(dataValue);            // Set Pot to Minimum Welding Current.
-  Wire.endTransmission();
-  return true;
+  bool success = false;
+  if (chipAddr != 0)
+  {
+    Wire.beginTransmission(chipAddr); // I2C Addr
+    Wire.write(memAddr | POT_WR_CMD); // Write Command
+    Wire.write(dataValue);            // Set Pot to Minimum Welding Current.
+    success = Wire.endTransmission() == I2C_ERROR_OK;
+  }
+
+  if (csPin != 0)
+  {
+    digitalWrite(csPin, LOW);
+    byte resp1 = SPI.transfer(memAddr | POT_WR_CMD);
+    SPI.write(dataValue);
+    digitalWrite(csPin, HIGH);
+
+    success = ((resp1 & 0x02) == 0x02);
+    // we have an issue here. Bit 1 of first response byte must be 1
+    // with 0 either the MCP41HVx1 signals a in isse or it is not connected
+  }
+
+  return success;
 }
 
 // *********************************************************************************************
-// Primitive Read value for the MCP45HV51 digital Pot.
-byte digitalPotRead(byte memAddr, byte chipAddr)
+// Primitive Read value for the MCP4xHV51 digital Pot.
+byte digitalPotRead(byte memAddr)
 {
-  byte dataByte;
+  byte dataByte{0};
+  bool success = false;
 
-  Wire.beginTransmission(chipAddr);                     // Addr
-  Wire.write(memAddr | POT_RD_CMD);                     // Read Command
-  Wire.requestFrom((uint16_t)(chipAddr), (uint8_t)(2)); // Request two bytes from Dig Pot.
-  Wire.read();                                          // Toss out first byte, always zero.
-  dataByte = Wire.read();                               // Get Data.
-  Wire.endTransmission();
+  if (chipAddr != 0)
+  {
+    Wire.beginTransmission(chipAddr);                     // Addr
+    Wire.write(memAddr | POT_RD_CMD);                     // Read Command
+    Wire.requestFrom((uint16_t)(chipAddr), (uint8_t)(2)); // Request two bytes from Dig Pot.
+    Wire.read();                                          // Toss out first byte, always zero.
+    dataByte = Wire.read();                               // Get Data.
+    success = Wire.endTransmission() == I2C_ERROR_OK;
+  }
 
+  if (csPin != 0)
+  {
+    digitalWrite(csPin, LOW);
+    byte resp1 = SPI.transfer(memAddr | POT_RD_CMD);
+    dataByte = SPI.transfer(0);
+    digitalWrite(csPin, HIGH);
+    
+    success = ((resp1 & 0x02) == 0x02 );
+    // we have an issue here. Bit 1 of first response byte must be 1
+    // with 0 either the MCP4xHVx1 signals a in isse or it is not connected
+    
+  }
+
+  if (success == false)
+  {
+      // TODO: implement a better error reporting
+      dataByte = 0;
+  }
   return dataByte;
 }
 

--- a/src/PulseWelder/src/misc.cpp
+++ b/src/PulseWelder/src/misc.cpp
@@ -183,7 +183,7 @@ void remoteControl(void)
 
     Serial.println(String(amps100) + "-" + String(amps10) + "-" + String(amps1));
 
-    setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+    setPotAmps(setAmps, true); // Refresh Digital Pot.
 
     if (spkrVolSwitch != VOL_OFF) {
       if (amps100 > 0) {                     // Suppress extraneous leading zero.
@@ -221,7 +221,7 @@ void pulseModulation(void)
 
   if (pulseSwitch == PULSE_OFF) { // Pulse mode is disabled. Refresh Digital POT every 0.5Sec, exit.
     if (millis() > previousMillis + 500) {
-      setPotAmps(setAmps, POT_I2C_ADDR, false);
+      setPotAmps(setAmps, false);
       previousMillis = millis();
     }
     pulseState = true;                      // Arc current in On.
@@ -245,7 +245,7 @@ void pulseModulation(void)
       ampVal = constrain(ampVal, MIN_SET_AMPS, MAX_SET_AMPS);
 
       //          Serial.println("Amps: " + String(setAmps) + ", bg: " + String(ampVal));  // Debug.
-      setPotAmps((byte)(ampVal), POT_I2C_ADDR, false);
+      setPotAmps((byte)(ampVal), false);
     }
   }
 }

--- a/src/PulseWelder/src/screen.cpp
+++ b/src/PulseWelder/src/screen.cpp
@@ -311,7 +311,7 @@ void processScreen(void)
 
         if (arcSwitch == ARC_ON) {
           Serial.println("Arc Current Turned On (" + String(setAmps) + " Amps)");
-          setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+          setPotAmps(setAmps, true); // Refresh Digital Pot.
 
           if (spkrVolSwitch != VOL_OFF) {
             DacAudio.Play(&highBeep, true);
@@ -319,7 +319,7 @@ void processScreen(void)
         }
         else {
           Serial.println("Arc Current Turned Off (limited to " + String(SET_AMPS_DISABLE) + " Amps).");
-          setPotAmps(SET_AMPS_DISABLE, POT_I2C_ADDR, true); // Set Digital Pot to lowest welding current.
+          setPotAmps(SET_AMPS_DISABLE, true); // Set Digital Pot to lowest welding current.
 
           if (spkrVolSwitch != VOL_OFF) {
             DacAudio.Play(&lowBeep, true);
@@ -403,7 +403,7 @@ void processScreen(void)
         setAmpsActive    = true;
         setAmps++;
         setAmps = constrain(setAmps, MIN_SET_AMPS, MAX_SET_AMPS);
-        setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+        setPotAmps(setAmps, true); // Refresh Digital Pot.
         displayAmps(true);                       // Refresh displayed value.
         arrowMillis       = millis();
         previousEepMillis = millis();
@@ -431,7 +431,7 @@ void processScreen(void)
         setAmpsActive    = true;
         setAmps--;
         setAmps = constrain(setAmps, MIN_SET_AMPS, MAX_SET_AMPS);
-        setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+        setPotAmps(setAmps, true); // Refresh Digital Pot.
         displayAmps(true);                       // Refresh displayed value.
         arrowMillis       = millis();
         previousEepMillis = millis();
@@ -468,10 +468,10 @@ void processScreen(void)
         displayAmps(true); // Refresh Amps display to update background color.
 
         if (arcSwitch == ARC_ON) {
-          setPotAmps(setAmps, POT_I2C_ADDR, false);
+          setPotAmps(setAmps, false);
         }
         else {
-          setPotAmps(SET_AMPS_DISABLE, POT_I2C_ADDR, false);
+          setPotAmps(SET_AMPS_DISABLE, false);
         }
         previousEepMillis = millis();
         eepromActive      = true; // Request EEProm Write after timer expiry.
@@ -500,7 +500,7 @@ void processScreen(void)
           eepromActive      = true;                // Request EEProm Write after timer expiry.
           setAmps++;
           setAmps = constrain(setAmps, MIN_SET_AMPS, MAX_SET_AMPS);
-          setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+          setPotAmps(setAmps, true); // Refresh Digital Pot.
           displayAmps(true);                       // Refresh amps value.
 
           if (spkrVolSwitch != VOL_OFF) {
@@ -535,7 +535,7 @@ void processScreen(void)
           eepromActive      = true;                // Request EEProm Write after timer expiry.
           setAmps--;
           setAmps = constrain(setAmps, MIN_SET_AMPS, MAX_SET_AMPS);
-          setPotAmps(setAmps, POT_I2C_ADDR, true); // Refresh Digital Pot.
+          setPotAmps(setAmps, true); // Refresh Digital Pot.
           displayAmps(true);                       // Refresh value.
 
           if (spkrVolSwitch != VOL_OFF) {


### PR DESCRIPTION
Code will autodetect if there is a MCP45HV51 connected via I2C or a MCP41HV51 via SPI.
MCP41HV51 uses GPIO26 for CS and the normal MISO/MOSI/SCLK lines (same as touchscreen and display)

Code changes outside of digPot.cpp are only removal of explicit mentioning
of the I2C address (which now stored at detection time) and of course, the new init call.